### PR TITLE
fix: remove /src/ from .npmignore (for sourcemaps)

### DIFF
--- a/packages/crc32/.npmignore
+++ b/packages/crc32/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /test/
 /coverage/
 /docs/

--- a/packages/ie11-detection/.npmignore
+++ b/packages/ie11-detection/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /test/
 /coverage/
 /docs/

--- a/packages/random-source-browser/.npmignore
+++ b/packages/random-source-browser/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /test/
 /coverage/
 /docs/

--- a/packages/random-source-node/.npmignore
+++ b/packages/random-source-node/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /test/
 /coverage/
 /docs/

--- a/packages/random-source-universal/.npmignore
+++ b/packages/random-source-universal/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /test/
 /coverage/
 /docs/

--- a/packages/sha256-browser/.npmignore
+++ b/packages/sha256-browser/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /test/
 /coverage/
 /docs/

--- a/packages/sha256-js/.npmignore
+++ b/packages/sha256-js/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /test/
 /coverage/
 /docs/

--- a/packages/sha256-universal/.npmignore
+++ b/packages/sha256-universal/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /test/
 /coverage/
 /docs/

--- a/packages/supports-web-crypto/.npmignore
+++ b/packages/supports-web-crypto/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /test/
 /coverage/
 /docs/


### PR DESCRIPTION
This PR removes /src/ from .npmignore in every package so that original TS source files will be published to the npm registry. This is especially important for VSCode users because the VSCode debugger relies on source files for setting breakpoints in the debugger, for debugger call stacks, for "step into" original source, and any other debugger use-cases. Even outside of debugging use-cases, it's helpful for developers consuming transpiled libraries to have original source so they can better understand what the library is doing. Finally, some tools (e.g. https://github.com/Volune/source-map-loader/tree/fixes) will show warnings when sourcemaps are present but source files are missing, and this PR will fix these warnings.

This PR is analogous to aws-amplify/amplify-js#2680 which made the same change to AWS Amplify library earlier this year.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
