### PR TITLE
feat(sha256-js): expose synchronous digest

### DIFF
--- a/packages/sha256-js/src/jsSha256.ts
+++ b/packages/sha256-js/src/jsSha256.ts
@@ -42,7 +42,10 @@ export class Sha256 implements Hash {
     }
   }
 
-  async digest(): Promise<Uint8Array> {
+  /* This synchronous method keeps compatibility
+   * with the v2 aws-sdk.
+   */
+  digestSync(): Uint8Array {
     if (this.error) {
       throw this.error;
     }
@@ -56,6 +59,15 @@ export class Sha256 implements Hash {
     }
 
     return this.hash.digest();
+  }
+
+  /* The underlying digest method here is synchronous.
+   * To keep the same interface with the other hash functions
+   * the default is to expose this as an async method.
+   * However, it can sometimes be useful to have a sync method.
+   */
+  async digest(): Promise<Uint8Array> {
+    return this.digestSync()
   }
 }
 


### PR DESCRIPTION
Resolves #6

The underlying digest is synchronous.
The original version in the aws-sdk v2 exposed this synchronous version.
Wrapping up and exposing this function maintains backwards compatibility.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
