### PR TITLE
fix: Corrected all the @aws-crypto package.json files to point to the…

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:aws/aws-javascript-crypto-helpers.git"
+    "url": "git@github.com:aws/aws-sdk-js-crypto-helpers.git"
   },
   "author": {
     "name": "AWS Crypto Tools Team",

--- a/packages/crc32/package.json
+++ b/packages/crc32/package.json
@@ -10,7 +10,7 @@
   "types": "./build/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "git@github.com:aws/aws-javascript-crypto-helpers.git"
+    "url": "git@github.com:aws/aws-sdk-js-crypto-helpers.git"
   },
   "author": {
     "name": "AWS Crypto Tools Team",

--- a/packages/ie11-detection/package.json
+++ b/packages/ie11-detection/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:aws/aws-javascript-crypto-helpers.git"
+    "url": "git@github.com:aws/aws-sdk-js-crypto-helpers.git"
   },
   "author": {
     "name": "AWS Crypto Tools Team",

--- a/packages/random-source-browser/package.json
+++ b/packages/random-source-browser/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:aws/aws-javascript-crypto-helpers.git"
+    "url": "git@github.com:aws/aws-sdk-js-crypto-helpers.git"
   },
   "author": {
     "name": "AWS Crypto Tools Team",

--- a/packages/random-source-node/package.json
+++ b/packages/random-source-node/package.json
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:aws/aws-javascript-crypto-helpers.git"
+    "url": "git@github.com:aws/aws-sdk-js-crypto-helpers.git"
   },
   "author": {
     "name": "AWS Crypto Tools Team",

--- a/packages/random-source-universal/package.json
+++ b/packages/random-source-universal/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:aws/aws-javascript-crypto-helpers.git"
+    "url": "git@github.com:aws/aws-sdk-js-crypto-helpers.git"
   },
   "author": {
     "name": "AWS Crypto Tools Team",

--- a/packages/sha256-browser/package.json
+++ b/packages/sha256-browser/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:aws/aws-javascript-crypto-helpers.git"
+    "url": "git@github.com:aws/aws-sdk-js-crypto-helpers.git"
   },
   "author": {
     "name": "AWS Crypto Tools Team",

--- a/packages/sha256-js/package.json
+++ b/packages/sha256-js/package.json
@@ -10,7 +10,7 @@
   "types": "./build/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "git@github.com:aws/aws-javascript-crypto-helpers.git"
+    "url": "git@github.com:aws/aws-sdk-js-crypto-helpers.git"
   },
   "author": {
     "name": "AWS Crypto Tools Team",

--- a/packages/sha256-universal/package.json
+++ b/packages/sha256-universal/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:aws/aws-javascript-crypto-helpers.git"
+    "url": "git@github.com:aws/aws-sdk-js-crypto-helpers.git"
   },
   "author": {
     "name": "AWS Crypto Tools Team",

--- a/packages/supports-web-crypto/package.json
+++ b/packages/supports-web-crypto/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:aws/aws-javascript-crypto-helpers.git"
+    "url": "git@github.com:aws/aws-sdk-js-crypto-helpers.git"
   },
   "author": {
     "name": "AWS Crypto Tools Team",


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-js-crypto-helpers/issues/8

*Description of changes:*
Changed all the package.json files to point to the aws-sdk-js-crypto-helpers Git repository. It was previously pointing to a non-existent repository.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
