### PR TITLE
fix: es2015.iterable required

### DIFF
--- a/packages/sha256-browser/tsconfig.json
+++ b/packages/sha256-browser/tsconfig.json
@@ -6,7 +6,8 @@
       "dom",
       "es5",
       "es2015.promise",
-      "es2015.collection"
+      "es2015.collection",
+      "es2015.iterable"
     ],
     "declaration": true,
     "sourceMap": true,

--- a/packages/sha256-js/tsconfig.json
+++ b/packages/sha256-js/tsconfig.json
@@ -9,7 +9,8 @@
     "lib": [
       "es5",
       "es2015.promise",
-      "es2015.collection"
+      "es2015.collection",
+      "es2015.iterable"
     ],
     "rootDir": "./src",
     "outDir": "./build",


### PR DESCRIPTION
Both sha256-js and sha256-browser use `es2015.iterable`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
