### PR TITLE
fix: upgrade handlebars to address https://www.npmjs.com/advisories/1316

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3335,9 +3335,9 @@
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
     },
     "handlebars": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.1.tgz",
-      "integrity": "sha512-C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.2.tgz",
+      "integrity": "sha512-29Zxv/cynYB7mkT1rVWQnV7mGX6v7H/miQ6dbEpYTKq5eJBN7PsRB+ViYJlcT6JINTSu4dVB9kOqEun78h6Exg==",
       "requires": {
         "neo-async": "^2.6.0",
         "optimist": "^0.6.1",


### PR DESCRIPTION
_Issue:_ 
"npm install" reported 2 vulnerabilities on handlebars 4.5.1 (and prior) disclosed Nov 14, 2019: https://www.npmjs.com/advisories/1316

_Description of changes:_ 
Ran "npm audit fix" which updated package-lock.json to use handlebars 4.5.2. "npm install; npm run bootstrap" completed the file.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
