### PR TITLE
chore: Fix CI Action for run

### DIFF
--- a/.github/workflows/ci-unit-tests.yaml
+++ b/.github/workflows/ci-unit-tests.yaml
@@ -21,9 +21,6 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node }}
-      - run: |
-          npm install
-          npm run bootstrap
-      - name: npm test
-        env:
-          run: npm test
+      - run: npm ci
+      - run: npm run bootstrap
+      - run: npm test


### PR DESCRIPTION
Each GA step needs a `run` or a `uses`.
I do not see any advantage to having one step for each npm command.
Also, it should be `npm ci` to use the package-lock.json


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
