### PR TITLE
fix: replace `sourceRoot` -> `rootDir` in tsconfig

### DIFF
--- a/packages/ie11-detection/tsconfig.json
+++ b/packages/ie11-detection/tsconfig.json
@@ -7,7 +7,7 @@
     "sourceMap": true,
     "declaration": true,
     "stripInternal": true,
-    "sourceRoot": "./src",
+    "rootDir": "./src",
     "outDir": "./build",
     "importHelpers": true,
     "noEmitHelpers": true

--- a/packages/ie11-detection/tsconfig.test.json
+++ b/packages/ie11-detection/tsconfig.test.json
@@ -4,7 +4,7 @@
     "sourceMap": false,
     "inlineSourceMap": true,
     "inlineSources": true,
-    "sourceRoot": "./src",
+    "rootDir": "./src",
     "outDir": "./build"
   }
 }

--- a/packages/random-source-browser/tsconfig.json
+++ b/packages/random-source-browser/tsconfig.json
@@ -6,7 +6,7 @@
     "declaration": true,
     "sourceMap": true,
     "strict": true,
-    "sourceRoot": "./src",
+    "rootDir": "./src",
     "outDir": "./build",
     "importHelpers": true,
     "noEmitHelpers": true

--- a/packages/random-source-browser/tsconfig.test.json
+++ b/packages/random-source-browser/tsconfig.test.json
@@ -4,7 +4,7 @@
     "sourceMap": false,
     "inlineSourceMap": true,
     "inlineSources": true,
-    "sourceRoot": "./src",
+    "rootDir": "./src",
     "outDir": "./build",
     "types": ["node"]
   }

--- a/packages/random-source-node/tsconfig.json
+++ b/packages/random-source-node/tsconfig.json
@@ -6,7 +6,7 @@
     "declaration": true,
     "sourceMap": true,
     "strict": true,
-    "sourceRoot": "./src",
+    "rootDir": "./src",
     "outDir": "./build",
     "importHelpers": true,
     "noEmitHelpers": true

--- a/packages/random-source-node/tsconfig.test.json
+++ b/packages/random-source-node/tsconfig.test.json
@@ -4,7 +4,7 @@
     "sourceMap": false,
     "inlineSourceMap": true,
     "inlineSources": true,
-    "sourceRoot": "./src",
+    "rootDir": "./src",
     "outDir": "./build"
   }
 }

--- a/packages/supports-web-crypto/tsconfig.json
+++ b/packages/supports-web-crypto/tsconfig.json
@@ -6,7 +6,7 @@
     "strict": true,
     "sourceMap": true,
     "declaration": true,
-    "sourceRoot": "./src",
+    "rootDir": "./src",
     "outDir": "./build",
     "importHelpers": true,
     "noEmitHelpers": true

--- a/packages/supports-web-crypto/tsconfig.test.json
+++ b/packages/supports-web-crypto/tsconfig.test.json
@@ -4,7 +4,7 @@
     "sourceMap": false,
     "inlineSourceMap": true,
     "inlineSources": true,
-    "sourceRoot": "./src",
+    "rootDir": "./src",
     "outDir": "./build"
   }
 }


### PR DESCRIPTION
This PR changes `sourceRoot` to `rootDir` in tsconfig.json for 4 of the packages in this repo. (All other packages already used `rootDir`.) 

This change is helpful because using `sourceRoot` creates sourcemaps that some tools cannot read correctly, leading to build warnings and/or debuggers like VSCode being unable to debug into original source files.

Related: https://github.com/aws/aws-sdk-js-v3/pull/1462 includes a similar change for the SDKV3 repo.

BTW, this is a follow-up to my other sourcemap-related PR #5 that was merged last year. Slowly but surely I'm trying to get all AWS libraries to be easily debuggable with sourcemaps! ;-)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
