### PR TITLE
chore(deps-dev): bump @aws-sdk deps to rc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -157,29 +157,10 @@
         }
       }
     },
-    "@aws-sdk/is-array-buffer": {
-      "version": "1.0.0-gamma.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-1.0.0-gamma.4.tgz",
-      "integrity": "sha512-HYOyS2fkLakcRrdvDxGw+s2LIPg7SNSXQAIA3F/QTS8UGa8CHU5EujRSsYzwC6FxG3W5ND+nCsKeI/OGc/NfZw==",
-      "dev": true,
-      "requires": {
-        "tslib": "^1.8.0"
-      }
-    },
     "@aws-sdk/types": {
       "version": "1.0.0-gamma.3",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-1.0.0-gamma.3.tgz",
       "integrity": "sha512-6Zu64X/6I8Y0gO/+J2CGXjYUmYkiI89MX3BEgRcQRh3jUNpKnOm1j4r40w4qsu1QAYxwWJL1M/rjLJPOQPV7zw=="
-    },
-    "@aws-sdk/util-buffer-from": {
-      "version": "1.0.0-gamma.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-1.0.0-gamma.4.tgz",
-      "integrity": "sha512-lwPNy7Qj+PJsKRdiGxLIZ0UZJsDq8Sm+EZwqs587dzWBpD0F4CwaR7sJvcS014KlEIDKYC+qWDpQQGROvxloHQ==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/is-array-buffer": "1.0.0-gamma.4",
-        "tslib": "^1.8.0"
-      }
     },
     "@aws-sdk/util-hex-encoding": {
       "version": "1.0.0-gamma.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,14 +21,14 @@
       "requires": {
         "@aws-crypto/ie11-detection": "file:packages/ie11-detection",
         "@aws-crypto/supports-web-crypto": "file:packages/supports-web-crypto",
-        "@aws-sdk/util-locate-window": "^1.0.0-gamma.1",
+        "@aws-sdk/util-locate-window": "^1.0.0-rc.1",
         "tslib": "^1.11.1"
       }
     },
     "@aws-crypto/random-source-node": {
       "version": "file:packages/random-source-node",
       "requires": {
-        "@aws-sdk/types": "^1.0.0-gamma.1",
+        "@aws-sdk/types": "^1.0.0-rc.1",
         "tslib": "^1.11.1"
       }
     },
@@ -37,7 +37,7 @@
       "requires": {
         "@aws-crypto/random-source-browser": "file:packages/random-source-browser",
         "@aws-crypto/random-source-node": "file:packages/random-source-node",
-        "@aws-sdk/types": "^1.0.0-gamma.1",
+        "@aws-sdk/types": "^1.0.0-rc.1",
         "tslib": "^1.11.1"
       },
       "dependencies": {
@@ -54,9 +54,9 @@
         "@aws-crypto/ie11-detection": "file:packages/ie11-detection",
         "@aws-crypto/sha256-js": "file:packages/sha256-js",
         "@aws-crypto/supports-web-crypto": "file:packages/supports-web-crypto",
-        "@aws-sdk/types": "^1.0.0-gamma.1",
-        "@aws-sdk/util-locate-window": "^1.0.0-gamma.1",
-        "@aws-sdk/util-utf8-browser": "^1.0.0-gamma.1",
+        "@aws-sdk/types": "^1.0.0-rc.1",
+        "@aws-sdk/util-locate-window": "^1.0.0-rc.1",
+        "@aws-sdk/util-utf8-browser": "^1.0.0-rc.1",
         "tslib": "^1.11.1"
       },
       "dependencies": {
@@ -86,8 +86,8 @@
     "@aws-crypto/sha256-js": {
       "version": "file:packages/sha256-js",
       "requires": {
-        "@aws-sdk/types": "^1.0.0-gamma.1",
-        "@aws-sdk/util-utf8-browser": "^1.0.0-gamma.1",
+        "@aws-sdk/types": "^1.0.0-rc.1",
+        "@aws-sdk/util-utf8-browser": "^1.0.0-rc.1",
         "tslib": "^1.11.1"
       },
       "dependencies": {
@@ -110,8 +110,8 @@
       "version": "file:packages/sha256-universal",
       "requires": {
         "@aws-crypto/sha256-browser": "file:packages/sha256-browser",
-        "@aws-sdk/hash-node": "^1.0.0-gamma.1",
-        "@aws-sdk/types": "^1.0.0-gamma.1",
+        "@aws-sdk/hash-node": "^1.0.0-rc.1",
+        "@aws-sdk/types": "^1.0.0-rc.1",
         "tslib": "^1.11.1"
       },
       "dependencies": {
@@ -163,9 +163,9 @@
       "integrity": "sha512-6Zu64X/6I8Y0gO/+J2CGXjYUmYkiI89MX3BEgRcQRh3jUNpKnOm1j4r40w4qsu1QAYxwWJL1M/rjLJPOQPV7zw=="
     },
     "@aws-sdk/util-hex-encoding": {
-      "version": "1.0.0-gamma.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-1.0.0-gamma.4.tgz",
-      "integrity": "sha512-51NOiipVSg2kNkiuP8OCKjUnUsQ1JiTMAhixE+NjNPLWqPAiQ5kuLSwhtCj3V5OZssrgxMBOdhv75HTFKZP8pw==",
+      "version": "1.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-1.0.0-rc.1.tgz",
+      "integrity": "sha512-BIv8T8GrourrcrT7u/6mOsY6PZjfzozJohMkq9I34cnkrKbemOcPYWgKQAqtZCICrrVnXa0OCPxup40zAonvqw==",
       "dev": true,
       "requires": {
         "tslib": "^1.8.0"
@@ -180,9 +180,9 @@
       }
     },
     "@aws-sdk/util-utf8-browser": {
-      "version": "1.0.0-gamma.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-1.0.0-gamma.4.tgz",
-      "integrity": "sha512-HN4630DLbwc72fM+kszG3EwODjKbeCXP66zHzQvCdqzlNgb8D3FqkvyFKTMO+x3f0rX2ea7qZdw/1LtqHr33KQ==",
+      "version": "1.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-1.0.0-rc.1.tgz",
+      "integrity": "sha512-7PiEROSh/hZYlmvnlsEoejm34lniwfDkCp77jzwf2Bu0DKnH5rv6cnvTtmPXp49lMoIfwj5htde34lMlrhtBow==",
       "dev": true,
       "requires": {
         "tslib": "^1.8.0"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "packages/*"
   ],
   "devDependencies": {
-    "@aws-sdk/util-buffer-from": "^1.0.0-gamma.4",
     "@aws-sdk/util-hex-encoding": "^1.0.0-gamma.4",
     "@aws-sdk/util-utf8-browser": "^1.0.0-gamma.4",
     "@types/chai": "^4.2.12",

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "packages/*"
   ],
   "devDependencies": {
-    "@aws-sdk/util-hex-encoding": "^1.0.0-gamma.4",
-    "@aws-sdk/util-utf8-browser": "^1.0.0-gamma.4",
+    "@aws-sdk/util-hex-encoding": "^1.0.0-rc.1",
+    "@aws-sdk/util-utf8-browser": "^1.0.0-rc.1",
     "@types/chai": "^4.2.12",
     "@types/mocha": "^7.0.2",
     "@types/node": "^14.0.27",

--- a/packages/random-source-browser/package.json
+++ b/packages/random-source-browser/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@aws-crypto/ie11-detection": "file:../ie11-detection",
     "@aws-crypto/supports-web-crypto": "file:../supports-web-crypto",
-    "@aws-sdk/util-locate-window": "^1.0.0-gamma.1",
+    "@aws-sdk/util-locate-window": "^1.0.0-rc.1",
     "tslib": "^1.11.1"
   },
   "main": "./build/index.js",

--- a/packages/random-source-node/package.json
+++ b/packages/random-source-node/package.json
@@ -18,7 +18,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/types": "^1.0.0-gamma.1",
+    "@aws-sdk/types": "^1.0.0-rc.1",
     "tslib": "^1.11.1"
   },
   "types": "./build/index.d.ts"

--- a/packages/random-source-universal/package.json
+++ b/packages/random-source-universal/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@aws-crypto/random-source-browser": "file:../random-source-browser",
     "@aws-crypto/random-source-node": "file:../random-source-node",
-    "@aws-sdk/types": "^1.0.0-gamma.1",
+    "@aws-sdk/types": "^1.0.0-rc.1",
     "tslib": "^1.11.1"
   },
   "browser": {

--- a/packages/sha256-browser/package.json
+++ b/packages/sha256-browser/package.json
@@ -20,9 +20,9 @@
     "@aws-crypto/ie11-detection": "file:../ie11-detection",
     "@aws-crypto/sha256-js": "file:../sha256-js",
     "@aws-crypto/supports-web-crypto": "file:../supports-web-crypto",
-    "@aws-sdk/types": "^1.0.0-gamma.1",
-    "@aws-sdk/util-locate-window": "^1.0.0-gamma.1",
-    "@aws-sdk/util-utf8-browser": "^1.0.0-gamma.1",
+    "@aws-sdk/types": "^1.0.0-rc.1",
+    "@aws-sdk/util-locate-window": "^1.0.0-rc.1",
+    "@aws-sdk/util-utf8-browser": "^1.0.0-rc.1",
     "tslib": "^1.11.1"
   },
   "main": "./build/index.js",

--- a/packages/sha256-js/package.json
+++ b/packages/sha256-js/package.json
@@ -19,8 +19,8 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/types": "^1.0.0-gamma.1",
-    "@aws-sdk/util-utf8-browser": "^1.0.0-gamma.1",
+    "@aws-sdk/types": "^1.0.0-rc.1",
+    "@aws-sdk/util-utf8-browser": "^1.0.0-rc.1",
     "tslib": "^1.11.1"
   }
 }

--- a/packages/sha256-universal/package.json
+++ b/packages/sha256-universal/package.json
@@ -18,8 +18,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-crypto/sha256-browser": "file:../sha256-browser",
-    "@aws-sdk/hash-node": "^1.0.0-gamma.1",
-    "@aws-sdk/types": "^1.0.0-gamma.1",
+    "@aws-sdk/hash-node": "^1.0.0-rc.1",
+    "@aws-sdk/types": "^1.0.0-rc.1",
     "tslib": "^1.11.1"
   },
   "main": "./build/index.js",


### PR DESCRIPTION
_Issue #, if available:_
Similar to https://github.com/aws/aws-sdk-js-crypto-helpers/pull/144
AWS JavaScript SDK v3 has now published a Release Candidate https://github.com/aws/aws-sdk-js-v3/releases/tag/v1.0.0-rc.1

_Description of changes:_
* chore(deps-dev): remove unused dep @aws-sdk/util-buffer-from
* chore(deps-dev): bump @aws-sdk deps to rc

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
