### PR TITLE
chore(ci): drop Node.js 8.x

### DIFF
--- a/.github/workflows/ci-unit-tests.yaml
+++ b/.github/workflows/ci-unit-tests.yaml
@@ -13,7 +13,6 @@ jobs:
           - windows-latest
           - macos-latest
         node:
-          - 8
           - 10
           - 12
     steps:


### PR DESCRIPTION
_Issue #, if available:_
Node.js 8 was end-of-life on 2019-12-31: https://github.com/nodejs/Release#end-of-life-releases
Created issue to add Node.js 14.x in CI once it goes Active LTS: https://github.com/aws/aws-sdk-js-crypto-helpers/issues/179

_Description of changes:_
drop Node.js 8.x from CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
