### PR TITLE
chore(ci): add Node.js 14.x LTS

### DIFF
--- a/.github/workflows/ci-unit-tests.yaml
+++ b/.github/workflows/ci-unit-tests.yaml
@@ -16,6 +16,7 @@ jobs:
           - 8
           - 10
           - 12
+          - 14
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1


### PR DESCRIPTION
_Issue #, if available:_
Fixes: https://github.com/aws/aws-sdk-js-crypto-helpers/issues/179

_Description of changes:_
chore(ci): add Node.js 14.x LTS

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
