### PR TITLE
chore: bump aws-sdk to 3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,14 +21,14 @@
       "requires": {
         "@aws-crypto/ie11-detection": "file:packages/ie11-detection",
         "@aws-crypto/supports-web-crypto": "file:packages/supports-web-crypto",
-        "@aws-sdk/util-locate-window": "^1.0.0-rc.1",
+        "@aws-sdk/util-locate-window": "^3.0.0",
         "tslib": "^1.11.1"
       }
     },
     "@aws-crypto/random-source-node": {
       "version": "file:packages/random-source-node",
       "requires": {
-        "@aws-sdk/types": "^1.0.0-rc.1",
+        "@aws-sdk/types": "^3.0.0",
         "tslib": "^1.11.1"
       }
     },
@@ -37,14 +37,14 @@
       "requires": {
         "@aws-crypto/random-source-browser": "file:packages/random-source-browser",
         "@aws-crypto/random-source-node": "file:packages/random-source-node",
-        "@aws-sdk/types": "^1.0.0-rc.1",
+        "@aws-sdk/types": "^3.0.0",
         "tslib": "^1.11.1"
       },
       "dependencies": {
         "@aws-sdk/types": {
-          "version": "1.0.0-gamma.3",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-1.0.0-gamma.3.tgz",
-          "integrity": "sha512-6Zu64X/6I8Y0gO/+J2CGXjYUmYkiI89MX3BEgRcQRh3jUNpKnOm1j4r40w4qsu1QAYxwWJL1M/rjLJPOQPV7zw=="
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.0.0.tgz",
+          "integrity": "sha512-D2sSHRZRw0ixox5+Dx7xPvTfMLZQzxJ/nWDP26FAl+c/i/402d0Y9acfDtUxfxPxCbVogZ3XgZXhjDY/RmMAjQ=="
         }
       }
     },
@@ -54,29 +54,29 @@
         "@aws-crypto/ie11-detection": "file:packages/ie11-detection",
         "@aws-crypto/sha256-js": "file:packages/sha256-js",
         "@aws-crypto/supports-web-crypto": "file:packages/supports-web-crypto",
-        "@aws-sdk/types": "^1.0.0-rc.1",
-        "@aws-sdk/util-locate-window": "^1.0.0-rc.1",
-        "@aws-sdk/util-utf8-browser": "^1.0.0-rc.1",
+        "@aws-sdk/types": "^3.0.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       },
       "dependencies": {
         "@aws-sdk/types": {
-          "version": "1.0.0-gamma.3",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-1.0.0-gamma.3.tgz",
-          "integrity": "sha512-6Zu64X/6I8Y0gO/+J2CGXjYUmYkiI89MX3BEgRcQRh3jUNpKnOm1j4r40w4qsu1QAYxwWJL1M/rjLJPOQPV7zw=="
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.0.0.tgz",
+          "integrity": "sha512-D2sSHRZRw0ixox5+Dx7xPvTfMLZQzxJ/nWDP26FAl+c/i/402d0Y9acfDtUxfxPxCbVogZ3XgZXhjDY/RmMAjQ=="
         },
         "@aws-sdk/util-locate-window": {
-          "version": "1.0.0-gamma.4",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-1.0.0-gamma.4.tgz",
-          "integrity": "sha512-vWhGXPttXrvZhBeTjebbc5XZfRbwhlzzFHMkiMqvZ+m29ztS+EawtA3s3TArTIrBOLq7ciG6rX+FoI0//55G1Q==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.0.0.tgz",
+          "integrity": "sha512-BJxBb3Zeij6/41HlYBog6jThL1EMMN+MGkx7uyFu1LGYMVEHjX0yl+fuEJvJmOWwIUclxrZuIPejQhZCFtHDSw==",
           "requires": {
             "tslib": "^1.8.0"
           }
         },
         "@aws-sdk/util-utf8-browser": {
-          "version": "1.0.0-gamma.4",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-1.0.0-gamma.4.tgz",
-          "integrity": "sha512-HN4630DLbwc72fM+kszG3EwODjKbeCXP66zHzQvCdqzlNgb8D3FqkvyFKTMO+x3f0rX2ea7qZdw/1LtqHr33KQ==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.0.0.tgz",
+          "integrity": "sha512-7vTn2KFOjUter7wwCjyQ+iJWvREOI8WAYyXSbD222dkY3VB/DAYFtMDErc4Sh4Onu2WPzdKJ6fnYwCpAxibHOQ==",
           "requires": {
             "tslib": "^1.8.0"
           }
@@ -86,20 +86,20 @@
     "@aws-crypto/sha256-js": {
       "version": "file:packages/sha256-js",
       "requires": {
-        "@aws-sdk/types": "^1.0.0-rc.1",
-        "@aws-sdk/util-utf8-browser": "^1.0.0-rc.1",
+        "@aws-sdk/types": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       },
       "dependencies": {
         "@aws-sdk/types": {
-          "version": "1.0.0-gamma.3",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-1.0.0-gamma.3.tgz",
-          "integrity": "sha512-6Zu64X/6I8Y0gO/+J2CGXjYUmYkiI89MX3BEgRcQRh3jUNpKnOm1j4r40w4qsu1QAYxwWJL1M/rjLJPOQPV7zw=="
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.0.0.tgz",
+          "integrity": "sha512-D2sSHRZRw0ixox5+Dx7xPvTfMLZQzxJ/nWDP26FAl+c/i/402d0Y9acfDtUxfxPxCbVogZ3XgZXhjDY/RmMAjQ=="
         },
         "@aws-sdk/util-utf8-browser": {
-          "version": "1.0.0-gamma.4",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-1.0.0-gamma.4.tgz",
-          "integrity": "sha512-HN4630DLbwc72fM+kszG3EwODjKbeCXP66zHzQvCdqzlNgb8D3FqkvyFKTMO+x3f0rX2ea7qZdw/1LtqHr33KQ==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.0.0.tgz",
+          "integrity": "sha512-7vTn2KFOjUter7wwCjyQ+iJWvREOI8WAYyXSbD222dkY3VB/DAYFtMDErc4Sh4Onu2WPzdKJ6fnYwCpAxibHOQ==",
           "requires": {
             "tslib": "^1.8.0"
           }
@@ -110,15 +110,15 @@
       "version": "file:packages/sha256-universal",
       "requires": {
         "@aws-crypto/sha256-browser": "file:packages/sha256-browser",
-        "@aws-sdk/hash-node": "^1.0.0-rc.1",
-        "@aws-sdk/types": "^1.0.0-rc.1",
+        "@aws-sdk/hash-node": "^3.0.0",
+        "@aws-sdk/types": "^3.0.0",
         "tslib": "^1.11.1"
       },
       "dependencies": {
         "@aws-sdk/types": {
-          "version": "1.0.0-gamma.3",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-1.0.0-gamma.3.tgz",
-          "integrity": "sha512-6Zu64X/6I8Y0gO/+J2CGXjYUmYkiI89MX3BEgRcQRh3jUNpKnOm1j4r40w4qsu1QAYxwWJL1M/rjLJPOQPV7zw=="
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.0.0.tgz",
+          "integrity": "sha512-D2sSHRZRw0ixox5+Dx7xPvTfMLZQzxJ/nWDP26FAl+c/i/402d0Y9acfDtUxfxPxCbVogZ3XgZXhjDY/RmMAjQ=="
         }
       }
     },
@@ -129,38 +129,35 @@
       }
     },
     "@aws-sdk/hash-node": {
-      "version": "1.0.0-gamma.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-1.0.0-gamma.4.tgz",
-      "integrity": "sha512-ToNYRGPhcwPSUBZyXBpO8f8fjmjIb4+5h++ZpbDEi6nuNxV0xpyEKL8J8xFVeo4fCxadrYBeE1zROaRjk7VAHw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.0.0.tgz",
+      "integrity": "sha512-AMKT/Tg5AmJPBA2yyERf0pA8T7+Pr9Ss1ZBYN8QGc3mLtH168uHdi85pu/5fv8+ubEO6NVyPD6MAibgWWIQ0rw==",
       "requires": {
-        "@aws-sdk/types": "1.0.0-gamma.3",
-        "@aws-sdk/util-buffer-from": "1.0.0-gamma.4",
+        "@aws-sdk/util-buffer-from": "3.0.0",
         "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": {
-          "version": "1.0.0-gamma.4",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-1.0.0-gamma.4.tgz",
-          "integrity": "sha512-HYOyS2fkLakcRrdvDxGw+s2LIPg7SNSXQAIA3F/QTS8UGa8CHU5EujRSsYzwC6FxG3W5ND+nCsKeI/OGc/NfZw==",
-          "requires": {
-            "tslib": "^1.8.0"
-          }
-        },
-        "@aws-sdk/util-buffer-from": {
-          "version": "1.0.0-gamma.4",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-1.0.0-gamma.4.tgz",
-          "integrity": "sha512-lwPNy7Qj+PJsKRdiGxLIZ0UZJsDq8Sm+EZwqs587dzWBpD0F4CwaR7sJvcS014KlEIDKYC+qWDpQQGROvxloHQ==",
-          "requires": {
-            "@aws-sdk/is-array-buffer": "1.0.0-gamma.4",
-            "tslib": "^1.8.0"
-          }
-        }
+      }
+    },
+    "@aws-sdk/is-array-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+      "integrity": "sha512-XEDXuZKHFDlBfeFU02b1bjN5KY2+7j+owXebe9A5qGKT2istaoY0TASidibJVd2qdj38zf+e8xKXvW/Akiha2Q==",
+      "requires": {
+        "tslib": "^1.8.0"
       }
     },
     "@aws-sdk/types": {
-      "version": "1.0.0-gamma.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-1.0.0-gamma.3.tgz",
-      "integrity": "sha512-6Zu64X/6I8Y0gO/+J2CGXjYUmYkiI89MX3BEgRcQRh3jUNpKnOm1j4r40w4qsu1QAYxwWJL1M/rjLJPOQPV7zw=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.0.0.tgz",
+      "integrity": "sha512-D2sSHRZRw0ixox5+Dx7xPvTfMLZQzxJ/nWDP26FAl+c/i/402d0Y9acfDtUxfxPxCbVogZ3XgZXhjDY/RmMAjQ=="
+    },
+    "@aws-sdk/util-buffer-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-Z/tU7/O0G2lYImMvAchCrPk2L8OmIs2pHi58kXEtHk/hxZXT1sJIZLErd3OFYaDFLaqOeEkebWB+jseBXJLv3Q==",
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.0.0",
+        "tslib": "^1.8.0"
+      }
     },
     "@aws-sdk/util-hex-encoding": {
       "version": "1.0.0-rc.1",
@@ -172,9 +169,9 @@
       }
     },
     "@aws-sdk/util-locate-window": {
-      "version": "1.0.0-gamma.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-1.0.0-gamma.4.tgz",
-      "integrity": "sha512-vWhGXPttXrvZhBeTjebbc5XZfRbwhlzzFHMkiMqvZ+m29ztS+EawtA3s3TArTIrBOLq7ciG6rX+FoI0//55G1Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.0.0.tgz",
+      "integrity": "sha512-BJxBb3Zeij6/41HlYBog6jThL1EMMN+MGkx7uyFu1LGYMVEHjX0yl+fuEJvJmOWwIUclxrZuIPejQhZCFtHDSw==",
       "requires": {
         "tslib": "^1.8.0"
       }

--- a/packages/random-source-browser/package.json
+++ b/packages/random-source-browser/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@aws-crypto/ie11-detection": "file:../ie11-detection",
     "@aws-crypto/supports-web-crypto": "file:../supports-web-crypto",
-    "@aws-sdk/util-locate-window": "^1.0.0-rc.1",
+    "@aws-sdk/util-locate-window": "^3.0.0",
     "tslib": "^1.11.1"
   },
   "main": "./build/index.js",

--- a/packages/random-source-node/package.json
+++ b/packages/random-source-node/package.json
@@ -18,7 +18,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/types": "^1.0.0-rc.1",
+    "@aws-sdk/types": "^3.0.0",
     "tslib": "^1.11.1"
   },
   "types": "./build/index.d.ts"

--- a/packages/random-source-universal/package.json
+++ b/packages/random-source-universal/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@aws-crypto/random-source-browser": "file:../random-source-browser",
     "@aws-crypto/random-source-node": "file:../random-source-node",
-    "@aws-sdk/types": "^1.0.0-rc.1",
+    "@aws-sdk/types": "^3.0.0",
     "tslib": "^1.11.1"
   },
   "browser": {

--- a/packages/sha256-browser/package.json
+++ b/packages/sha256-browser/package.json
@@ -20,9 +20,9 @@
     "@aws-crypto/ie11-detection": "file:../ie11-detection",
     "@aws-crypto/sha256-js": "file:../sha256-js",
     "@aws-crypto/supports-web-crypto": "file:../supports-web-crypto",
-    "@aws-sdk/types": "^1.0.0-rc.1",
-    "@aws-sdk/util-locate-window": "^1.0.0-rc.1",
-    "@aws-sdk/util-utf8-browser": "^1.0.0-rc.1",
+    "@aws-sdk/types": "^3.0.0",
+    "@aws-sdk/util-locate-window": "^3.0.0",
+    "@aws-sdk/util-utf8-browser": "^3.0.0",
     "tslib": "^1.11.1"
   },
   "main": "./build/index.js",

--- a/packages/sha256-js/package.json
+++ b/packages/sha256-js/package.json
@@ -19,8 +19,8 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/types": "^1.0.0-rc.1",
-    "@aws-sdk/util-utf8-browser": "^1.0.0-rc.1",
+    "@aws-sdk/types": "^3.0.0",
+    "@aws-sdk/util-utf8-browser": "^3.0.0",
     "tslib": "^1.11.1"
   }
 }

--- a/packages/sha256-universal/package.json
+++ b/packages/sha256-universal/package.json
@@ -18,8 +18,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-crypto/sha256-browser": "file:../sha256-browser",
-    "@aws-sdk/hash-node": "^1.0.0-rc.1",
-    "@aws-sdk/types": "^1.0.0-rc.1",
+    "@aws-sdk/hash-node": "^3.0.0",
+    "@aws-sdk/types": "^3.0.0",
     "tslib": "^1.11.1"
   },
   "main": "./build/index.js",


### PR DESCRIPTION
AWS SDK v3 is now GA. Bump v3 dependencies to the GA version

/cc @seebees 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
