### PR TITLE
fix(deps-dev): move @aws-sdk/types to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
     "@aws-crypto/random-source-node": {
       "version": "file:packages/random-source-node",
       "requires": {
+        "@aws-sdk/types": "^3.0.0",
         "tslib": "^1.11.1"
       }
     },
@@ -139,6 +140,11 @@
       "requires": {
         "tslib": "^1.8.0"
       }
+    },
+    "@aws-sdk/types": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.0.0.tgz",
+      "integrity": "sha512-D2sSHRZRw0ixox5+Dx7xPvTfMLZQzxJ/nWDP26FAl+c/i/402d0Y9acfDtUxfxPxCbVogZ3XgZXhjDY/RmMAjQ=="
     },
     "@aws-sdk/util-buffer-from": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
     "@aws-crypto/random-source-node": {
       "version": "file:packages/random-source-node",
       "requires": {
-        "@aws-sdk/types": "^3.0.0",
         "tslib": "^1.11.1"
       }
     },
@@ -37,7 +36,6 @@
       "requires": {
         "@aws-crypto/random-source-browser": "file:packages/random-source-browser",
         "@aws-crypto/random-source-node": "file:packages/random-source-node",
-        "@aws-sdk/types": "^3.0.0",
         "tslib": "^1.11.1"
       },
       "dependencies": {
@@ -54,7 +52,6 @@
         "@aws-crypto/ie11-detection": "file:packages/ie11-detection",
         "@aws-crypto/sha256-js": "file:packages/sha256-js",
         "@aws-crypto/supports-web-crypto": "file:packages/supports-web-crypto",
-        "@aws-sdk/types": "^3.0.0",
         "@aws-sdk/util-locate-window": "^3.0.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
@@ -86,7 +83,6 @@
     "@aws-crypto/sha256-js": {
       "version": "file:packages/sha256-js",
       "requires": {
-        "@aws-sdk/types": "^3.0.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       },
@@ -111,7 +107,6 @@
       "requires": {
         "@aws-crypto/sha256-browser": "file:packages/sha256-browser",
         "@aws-sdk/hash-node": "^3.0.0",
-        "@aws-sdk/types": "^3.0.0",
         "tslib": "^1.11.1"
       },
       "dependencies": {
@@ -144,11 +139,6 @@
       "requires": {
         "tslib": "^1.8.0"
       }
-    },
-    "@aws-sdk/types": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.0.0.tgz",
-      "integrity": "sha512-D2sSHRZRw0ixox5+Dx7xPvTfMLZQzxJ/nWDP26FAl+c/i/402d0Y9acfDtUxfxPxCbVogZ3XgZXhjDY/RmMAjQ=="
     },
     "@aws-sdk/util-buffer-from": {
       "version": "3.0.0",

--- a/packages/random-source-node/package.json
+++ b/packages/random-source-node/package.json
@@ -18,8 +18,10 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/types": "^3.0.0",
     "tslib": "^1.11.1"
+  },
+  "devDependencies": {
+    "@aws-sdk/types": "^3.0.0"
   },
   "types": "./build/index.d.ts"
 }

--- a/packages/random-source-node/package.json
+++ b/packages/random-source-node/package.json
@@ -18,10 +18,8 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/types": "^3.0.0",
     "tslib": "^1.11.1"
-  },
-  "devDependencies": {
-    "@aws-sdk/types": "^3.0.0"
   },
   "types": "./build/index.d.ts"
 }

--- a/packages/random-source-universal/package.json
+++ b/packages/random-source-universal/package.json
@@ -19,8 +19,10 @@
   "dependencies": {
     "@aws-crypto/random-source-browser": "file:../random-source-browser",
     "@aws-crypto/random-source-node": "file:../random-source-node",
-    "@aws-sdk/types": "^3.0.0",
     "tslib": "^1.11.1"
+  },
+  "devDependencies": {
+    "@aws-sdk/types": "^3.0.0"
   },
   "browser": {
     "@aws/crypto-random-source-node": false

--- a/packages/sha256-browser/package.json
+++ b/packages/sha256-browser/package.json
@@ -20,10 +20,12 @@
     "@aws-crypto/ie11-detection": "file:../ie11-detection",
     "@aws-crypto/sha256-js": "file:../sha256-js",
     "@aws-crypto/supports-web-crypto": "file:../supports-web-crypto",
-    "@aws-sdk/types": "^3.0.0",
     "@aws-sdk/util-locate-window": "^3.0.0",
     "@aws-sdk/util-utf8-browser": "^3.0.0",
     "tslib": "^1.11.1"
+  },
+  "devDependencies": {
+    "@aws-sdk/types": "^3.0.0"
   },
   "main": "./build/index.js",
   "types": "./build/index.d.ts"

--- a/packages/sha256-js/package.json
+++ b/packages/sha256-js/package.json
@@ -19,8 +19,10 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/types": "^3.0.0",
     "@aws-sdk/util-utf8-browser": "^3.0.0",
     "tslib": "^1.11.1"
+  },
+  "devDependencies": {
+    "@aws-sdk/types": "^3.0.0"
   }
 }

--- a/packages/sha256-universal/package.json
+++ b/packages/sha256-universal/package.json
@@ -19,8 +19,10 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "file:../sha256-browser",
     "@aws-sdk/hash-node": "^3.0.0",
-    "@aws-sdk/types": "^3.0.0",
     "tslib": "^1.11.1"
+  },
+  "devDependencies": {
+    "@aws-sdk/types": "^3.0.0"
   },
   "main": "./build/index.js",
   "types": "./build/index.d.ts",


### PR DESCRIPTION
_Issue #, if available:_
Attempts to fix https://github.com/aws/aws-sdk-js-v3/issues/1842

_Description of changes:_
move `@aws-sdk/types` to devDependencies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
