### PR TITLE
chore: Add release verification script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3846,8 +3846,7 @@
       "dev": true,
       "requires": {
         "chardet": "^0.7.0",
-        "iconv-lite": "^0.4.24",
-        "tmp": "^0.0.33"
+        "iconv-lite": "^0.4.24"
       },
       "dependencies": {
         "iconv-lite": {
@@ -9199,12 +9198,12 @@
       }
     },
     "tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "~1.0.2"
+        "rimraf": "^3.0.0"
       }
     },
     "to-fast-properties": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "sinon": "^9.0.2",
     "ts-node": "^8.10.2",
     "tslib": "^1.13.0",
-    "typescript": "^4.1.3"
+    "typescript": "^4.1.3",
+    "tmp": "^0.2.1"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "clean": "npm run clear-build-cache && lerna clean",
     "clear-build-cache": "rimraf ./packages/*/build/*",
     "pretest": "lerna run pretest",
-    "test": "lerna run test"
+    "test": "lerna run test",
+    "verify-releases": "lerna exec --concurrency 1 $INIT_CWD/util/verify_release -- ."
   },
   "repository": {
     "type": "git",

--- a/util/verify_release
+++ b/util/verify_release
@@ -6,18 +6,30 @@
 // Intended primarily as a basic smoke test after publishing.
 
 const { execSync } = require('child_process')
+const path = require('path');
 const tmp = require('tmp')
+var fs = require('fs');
 
-const package = process.argv[2]
-const version = process.argv[3]
+const packageDir = process.argv[2]
+const packageConfigFile = path.join(packageDir, "package.json")
+const packageConfig = JSON.parse(fs.readFileSync(packageConfigFile, 'utf8'))
+const packageName = packageConfig.name
+const packageVersion = packageConfig.version
+const releaseIdentifier = `${packageName}@${packageVersion}`
+
+console.log(`\nVerifying ${releaseIdentifier} release...`)
 
 // Create a temporary directory to act as a dummy consuming project.
 // It's important not to use the current directory because npm will
 // walk the file tree upwards and potentially find unrelated node_modules directories!
-const projectDir = tmp.dirSync();
+// TODO-RS: An empty directory triggers several warnings, about things like missing
+// package.json and package-lock.json files. Can we clean this up in the future?
+const consumingPackageDir = tmp.dirSync();
 
 // Manually install the dependency
-execSync(`npm install --prefix ${projectDir.name} ${package}@${version}`)
+execSync(`npm install --prefix ${consumingPackageDir.name} ${releaseIdentifier}`)
 
 // Verify that it can be imported. This also ensures that types are available correctly.
-execSync(`ts-node -e "import * as everything from '${package}'"`)
+execSync(`ts-node -e "import * as everything from '${packageName}'"`)
+
+console.log(`SUCCESS: Verified ${releaseIdentifier} release!`)

--- a/util/verify_release
+++ b/util/verify_release
@@ -4,6 +4,7 @@
 
 // A very simple script to verify that a package can be installed and imported.
 // Intended primarily as a basic smoke test after publishing.
+// TODO-RS: Work out how to run this against verdaccio for pre-release verification too!
 
 const { execSync } = require('child_process')
 const path = require('path');

--- a/util/verify_release
+++ b/util/verify_release
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// A very simple script to verify that a package can be installed and imported.
+// Intended primarily as a basic smoke test after publishing.
+
+const { execSync } = require('child_process')
+const tmp = require('tmp')
+
+const package = process.argv[2]
+const version = process.argv[3]
+
+// Create a temporary directory to act as a dummy consuming project.
+// It's important not to use the current directory because npm will
+// walk the file tree upwards and potentially find unrelated node_modules directories!
+const projectDir = tmp.dirSync();
+
+// Manually install the dependency
+execSync(`npm install --prefix ${projectDir.name} ${package}@${version}`)
+
+// Verify that it can be imported. This also ensures that types are available correctly.
+execSync(`ts-node -e "import * as everything from '${package}'"`)

--- a/util/verify_release
+++ b/util/verify_release
@@ -9,7 +9,7 @@
 const { execSync } = require('child_process')
 const path = require('path');
 const tmp = require('tmp')
-var fs = require('fs');
+const fs = require('fs');
 
 const packageDir = process.argv[2]
 const packageConfigFile = path.join(packageDir, "package.json")


### PR DESCRIPTION
Adds a utility script to verify that a released package can be at least installed and loaded, along with a top-level npm script to run this for each package.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
