### PR TITLE
fix(sha256-browser): throw errors not string

### DIFF
--- a/packages/sha256-browser/src/ie11Sha256.ts
+++ b/packages/sha256-browser/src/ie11Sha256.ts
@@ -47,13 +47,13 @@ export class Sha256 implements Hash {
       operation =>
         new Promise((resolve, reject) => {
           operation.onerror = () => {
-            reject("Error encountered finalizing hash");
+            reject(new Error("Error encountered finalizing hash"));
           };
           operation.oncomplete = () => {
             if (operation.result) {
               resolve(new Uint8Array(operation.result));
             }
-            reject("Error encountered finalizing hash");
+            reject(new Error("Error encountered finalizing hash"));
           };
 
           operation.finish();
@@ -77,10 +77,10 @@ function getKeyPromise(secret: SourceData): Promise<Key> {
         resolve(keyOperation.result);
       }
 
-      reject("ImportKey completed without importing key.");
+      reject(new Error("ImportKey completed without importing key."));
     };
     keyOperation.onerror = () => {
-      reject("ImportKey failed to import key.");
+      reject(new Error("ImportKey failed to import key."));
     };
   });
 }


### PR DESCRIPTION
https://github.com/aws/aws-sdk-js-v3/issues/2292

_Description of changes:_ Promise should reject with a JS error instead of a string.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
