### PR TITLE
chore(crc32c): set publishConfig.access to public

### DIFF
--- a/packages/crc32c/package.json
+++ b/packages/crc32c/package.json
@@ -20,5 +20,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "tslib": "^1.11.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
When running `lerna publish` to publish a new scoped package, if
`publishConfig.access` is unset, then the package is published with
private visibility ("restricted") by default [1]. Since this package is
intended for public consumption, we should configure this property
accordingly.

[1] https://github.com/lerna/lerna/tree/main/commands/publish#publishconfigaccess

_Issue #, if available:_

_Description of changes:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
