### PR TITLE
chore: Use lerna fixed versioning

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,4 @@
 {
-  "packages": [
-    "packages/*"
-  ],
-  "version": "independent"
+  "packages": ["packages/*"],
+  "version": "1.1.1"
 }


### PR DESCRIPTION
Reference: https://github.com/lerna/lerna#fixedlocked-mode-default

1. Currently the SDK create a new tag for each new version each subpackage. This results in having too many tags to maintain.
2. Using independent versioning also adds some unnecessary complexity over the release system.
3. Most popular monorepos use fixed versioning, like Lerna, Babel

See: aws-sdk-js-v3 switched to fixed versioning with their release candidate in aws/aws-sdk-js-v3#1248
And aws/aws-encryption-sdk-javascript#523

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
