### PR TITLE
fix: Adding ie11-detection dep to sha1-browser

### DIFF
--- a/packages/sha1-browser/package.json
+++ b/packages/sha1-browser/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-crypto/ie11-detection": "file:../ie11-detection",
     "@aws-crypto/supports-web-crypto": "file:../supports-web-crypto",
     "@aws-sdk/types": "^3.1.0",
     "@aws-sdk/util-locate-window": "^3.0.0",


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
