### PR TITLE
fix: better pollyfill check for Buffer

### DIFF
--- a/packages/util/src/convertToBuffer.ts
+++ b/packages/util/src/convertToBuffer.ts
@@ -6,7 +6,7 @@ import { fromUtf8 as fromUtf8Browser } from "@aws-sdk/util-utf8-browser";
 
 // Quick polyfill
 const fromUtf8 =
-  Buffer && Buffer.from
+  typeof Buffer !== "undefined" && Buffer.from
     ? (input: string) => Buffer.from(input, "utf8")
     : fromUtf8Browser;
 


### PR DESCRIPTION
Referencing an undefined directly variable is causing an issue compiling.
Especially in Webpack.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
