### PR TITLE
fix(crc32c): ie11 does not support Array.from

### DIFF
--- a/packages/crc32/src/index.ts
+++ b/packages/crc32/src/index.ts
@@ -1,3 +1,5 @@
+import {uint32ArrayFrom} from "@aws-crypto/util";
+
 export function crc32(data: Uint8Array): number {
   return new Crc32().update(data).digest();
 }
@@ -20,7 +22,7 @@ export class Crc32 {
 }
 
 // prettier-ignore
-const lookupTable = Uint32Array.from([
+const a_lookUpTable = [
   0x00000000, 0x77073096, 0xEE0E612C, 0x990951BA,
   0x076DC419, 0x706AF48F, 0xE963A535, 0x9E6495A3,
   0x0EDB8832, 0x79DCB8A4, 0xE0D5E91E, 0x97D2D988,
@@ -85,6 +87,6 @@ const lookupTable = Uint32Array.from([
   0xBAD03605, 0xCDD70693, 0x54DE5729, 0x23D967BF,
   0xB3667A2E, 0xC4614AB8, 0x5D681B02, 0x2A6F2B94,
   0xB40BBE37, 0xC30C8EA1, 0x5A05DF1B, 0x2D02EF8D,
-]);
-
+];
+const lookupTable: Uint32Array = uint32ArrayFrom(a_lookUpTable)
 export { AwsCrc32 } from "./aws_crc32";

--- a/packages/crc32c/src/index.ts
+++ b/packages/crc32c/src/index.ts
@@ -1,3 +1,6 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 export function crc32c(data: Uint8Array): number {
   return new Crc32c().update(data).digest();
 }
@@ -20,7 +23,7 @@ export class Crc32c {
 }
 
 // prettier-ignore
-const lookupTable = Uint32Array.from([
+const a_lookupTable = [
   0x00000000, 0xF26B8303, 0xE13B70F7, 0x1350F3F4, 0xC79A971F, 0x35F1141C, 0x26A1E7E8, 0xD4CA64EB,
   0x8AD958CF, 0x78B2DBCC, 0x6BE22838, 0x9989AB3B, 0x4D43CFD0, 0xBF284CD3, 0xAC78BF27, 0x5E133C24,
   0x105EC76F, 0xE235446C, 0xF165B798, 0x030E349B, 0xD7C45070, 0x25AFD373, 0x36FF2087, 0xC494A384,
@@ -53,6 +56,13 @@ const lookupTable = Uint32Array.from([
   0x69E9F0D5, 0x9B8273D6, 0x88D28022, 0x7AB90321, 0xAE7367CA, 0x5C18E4C9, 0x4F48173D, 0xBD23943E,
   0xF36E6F75, 0x0105EC76, 0x12551F82, 0xE03E9C81, 0x34F4F86A, 0xC69F7B69, 0xD5CF889D, 0x27A40B9E,
   0x79B737BA, 0x8BDCB4B9, 0x988C474D, 0x6AE7C44E, 0xBE2DA0A5, 0x4C4623A6, 0x5F16D052, 0xAD7D5351,
-]);
+];
 
+// IE 11 does not support Array.from, so we do it manually
+const lookupTable = new Uint32Array(256);
+let a_index = 0;
+while (a_index < 256) {
+  lookupTable[a_index] = a_lookupTable[a_index];
+  a_index += 1;
+}
 export { AwsCrc32c } from "./aws_crc32c";

--- a/packages/crc32c/src/index.ts
+++ b/packages/crc32c/src/index.ts
@@ -1,6 +1,8 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import {uint32ArrayFrom} from "@aws-crypto/util";
+
 export function crc32c(data: Uint8Array): number {
   return new Crc32c().update(data).digest();
 }
@@ -58,11 +60,5 @@ const a_lookupTable = [
   0x79B737BA, 0x8BDCB4B9, 0x988C474D, 0x6AE7C44E, 0xBE2DA0A5, 0x4C4623A6, 0x5F16D052, 0xAD7D5351,
 ];
 
-// IE 11 does not support Array.from, so we do it manually
-const lookupTable = new Uint32Array(256);
-let a_index = 0;
-while (a_index < 256) {
-  lookupTable[a_index] = a_lookupTable[a_index];
-  a_index += 1;
-}
+const lookupTable: Uint32Array = uint32ArrayFrom(a_lookupTable)
 export { AwsCrc32c } from "./aws_crc32c";

--- a/packages/util/src/index.ts
+++ b/packages/util/src/index.ts
@@ -4,3 +4,4 @@
 export { convertToBuffer } from "./convertToBuffer";
 export { isEmptyData } from "./isEmptyData";
 export { numToUint8 } from "./numToUint8";
+export {uint32ArrayFrom} from './uint32ArrayFrom';

--- a/packages/util/src/uint32ArrayFrom.ts
+++ b/packages/util/src/uint32ArrayFrom.ts
@@ -1,0 +1,15 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// IE 11 does not support Array.from, so we do it manually
+export function uint32ArrayFrom(a_lookUpTable: Array<number>): Uint32Array {
+  if (!Array.from) {
+    const return_array = new Uint32Array(a_lookUpTable.length)
+    let a_index = 0
+    while (a_index < a_lookUpTable.length) {
+      return_array[a_index] = a_lookUpTable[a_index]
+    }
+    return return_array
+  }
+  return Uint32Array.from(a_lookUpTable)
+}


### PR DESCRIPTION
_Issue #, if available:_ IE 11 does not support Array.from

_Description of changes:_ Use a manual Array initialization to populate a `Uint32Array`.

_Not Fixed:_ There are still no browsers tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
