### PR TITLE
fix(uint32ArrayFrom): increment index & polyfill for Uint32Array

### DIFF
--- a/packages/util/src/uint32ArrayFrom.ts
+++ b/packages/util/src/uint32ArrayFrom.ts
@@ -3,11 +3,12 @@
 
 // IE 11 does not support Array.from, so we do it manually
 export function uint32ArrayFrom(a_lookUpTable: Array<number>): Uint32Array {
-  if (!Array.from) {
+  if (!Uint32Array.from) {
     const return_array = new Uint32Array(a_lookUpTable.length)
     let a_index = 0
     while (a_index < a_lookUpTable.length) {
       return_array[a_index] = a_lookUpTable[a_index]
+      a_index += 1
     }
     return return_array
   }

--- a/packages/util/test/uint32ArrayFrom.test.ts
+++ b/packages/util/test/uint32ArrayFrom.test.ts
@@ -17,6 +17,4 @@ describe("uint32ArrayFrom", () =>{
       .to
       .eql(Uint32Array.of(0, 4067132163, 3778769143))
   })
-
-
 })

--- a/packages/util/test/uint32ArrayFrom.test.ts
+++ b/packages/util/test/uint32ArrayFrom.test.ts
@@ -1,0 +1,22 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect } from "chai";
+import "mocha";
+import { uint32ArrayFrom } from "../src/uint32ArrayFrom";
+
+describe("uint32ArrayFrom", () =>{
+  it("When given an empty array, should return an empty array", () => {
+    expect(uint32ArrayFrom(Array.of(0)))
+      .to
+      .eql(Uint32Array.of(0))
+  })
+
+  it("Given a populated array, returns a valid Uint32 Array", () => {
+    expect(uint32ArrayFrom(Array.of(0x00000000, 0xF26B8303, 0xE13B70F7)))
+      .to
+      .eql(Uint32Array.of(0, 4067132163, 3778769143))
+  })
+
+
+})


### PR DESCRIPTION
_Issue #, if available:_ #269

_Description of changes:_ 
1. Increment index in Uint32Array, which was not happening in the while loop.
2. Detect if UInt32Array.From is missing, as compared to the generic Array.From

PR is not yet tested on IE 11

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
