### PR TITLE
fix[#337]: update @aws-sdk/types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@aws-crypto/util": "file:packages/util"
       },
       "devDependencies": {
-        "@aws-sdk/types": "^3.0.0",
+        "@aws-sdk/types": "^3.110.0",
         "@aws-sdk/util-buffer-from": "^3.29.0",
         "@aws-sdk/util-hex-encoding": "^3.29.0",
         "@aws-sdk/util-utf8-browser": "^3.29.0",
@@ -112,11 +112,11 @@
       "link": true
     },
     "node_modules/@aws-sdk/hash-node": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.55.0.tgz",
-      "integrity": "sha512-2UdYwY/++AlzWEAFaK9wOed2QSxbzV527vmqKjReLHpPKPrSIlooUxlTH3LU6Y6WVDAzDRtLK43KUVXTLgGK1A==",
+      "version": "3.110.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.110.0.tgz",
+      "integrity": "sha512-wakl+kP2O8wTGYiQ3InZy+CVfGrIpFfq9fo4zif9PZac0BbUbguUU1dkY34uZiaf+4o2/9MoDYrHU2HYeXKxWw==",
       "dependencies": {
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/types": "3.110.0",
         "@aws-sdk/util-buffer-from": "3.55.0",
         "tslib": "^2.3.1"
       },
@@ -146,9 +146,9 @@
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.55.0.tgz",
-      "integrity": "sha512-wrDZjuy1CVAYxDCbm3bWQIKMGfNs7XXmG0eG4858Ixgqmq2avsIn5TORy8ynBxcXn9aekV/+tGEQ7BBSYzIVNQ==",
+      "version": "3.110.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.110.0.tgz",
+      "integrity": "sha512-dLVoqODU3laaqNFPyN1QLtlQnwX4gNPMXptEBIt/iJpuZf66IYJe6WCzVZGt4Zfa1CnUmrlA428AzdcA/KCr2A==",
       "engines": {
         "node": ">= 12.0.0"
       }
@@ -12202,7 +12202,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/util": "file:../util",
-        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/types": "^3.110.0",
         "tslib": "^1.11.1"
       }
     },
@@ -12212,7 +12212,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/util": "file:../util",
-        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/types": "^3.110.0",
         "tslib": "^1.11.1"
       }
     },
@@ -12240,7 +12240,7 @@
       "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/types": "^3.110.0",
         "tslib": "^1.11.1"
       }
     },
@@ -12251,7 +12251,7 @@
       "dependencies": {
         "@aws-crypto/random-source-browser": "file:../random-source-browser",
         "@aws-crypto/random-source-node": "file:../random-source-node",
-        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/types": "^3.110.0",
         "tslib": "^1.11.1"
       }
     },
@@ -12262,7 +12262,7 @@
       "dependencies": {
         "@aws-crypto/ie11-detection": "file:../ie11-detection",
         "@aws-crypto/supports-web-crypto": "file:../supports-web-crypto",
-        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/types": "^3.110.0",
         "@aws-sdk/util-locate-window": "^3.0.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
@@ -12277,7 +12277,7 @@
         "@aws-crypto/sha256-js": "file:../sha256-js",
         "@aws-crypto/supports-web-crypto": "file:../supports-web-crypto",
         "@aws-crypto/util": "file:../util",
-        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/types": "^3.110.0",
         "@aws-sdk/util-locate-window": "^3.0.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
@@ -12289,7 +12289,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/util": "file:../util",
-        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/types": "^3.110.0",
         "tslib": "^1.11.1"
       }
     },
@@ -12299,8 +12299,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "file:../sha256-browser",
-        "@aws-sdk/hash-node": "^3.0.0",
-        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/hash-node": "^3.110.0",
+        "@aws-sdk/types": "^3.110.0",
         "tslib": "^1.11.1"
       }
     },
@@ -12317,7 +12317,7 @@
       "version": "2.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/types": "^3.110.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       }
@@ -12337,7 +12337,7 @@
       "version": "file:packages/crc32",
       "requires": {
         "@aws-crypto/util": "file:../util",
-        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/types": "^3.110.0",
         "tslib": "^1.11.1"
       }
     },
@@ -12345,7 +12345,7 @@
       "version": "file:packages/crc32c",
       "requires": {
         "@aws-crypto/util": "file:../util",
-        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/types": "^3.110.0",
         "tslib": "^1.11.1"
       }
     },
@@ -12367,7 +12367,7 @@
     "@aws-crypto/random-source-node": {
       "version": "file:packages/random-source-node",
       "requires": {
-        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/types": "^3.110.0",
         "tslib": "^1.11.1"
       }
     },
@@ -12376,7 +12376,7 @@
       "requires": {
         "@aws-crypto/random-source-browser": "file:../random-source-browser",
         "@aws-crypto/random-source-node": "file:../random-source-node",
-        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/types": "^3.110.0",
         "tslib": "^1.11.1"
       }
     },
@@ -12385,7 +12385,7 @@
       "requires": {
         "@aws-crypto/ie11-detection": "file:../ie11-detection",
         "@aws-crypto/supports-web-crypto": "file:../supports-web-crypto",
-        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/types": "^3.110.0",
         "@aws-sdk/util-locate-window": "^3.0.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
@@ -12398,7 +12398,7 @@
         "@aws-crypto/sha256-js": "file:../sha256-js",
         "@aws-crypto/supports-web-crypto": "file:../supports-web-crypto",
         "@aws-crypto/util": "file:../util",
-        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/types": "^3.110.0",
         "@aws-sdk/util-locate-window": "^3.0.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
@@ -12408,7 +12408,7 @@
       "version": "file:packages/sha256-js",
       "requires": {
         "@aws-crypto/util": "file:../util",
-        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/types": "^3.110.0",
         "tslib": "^1.11.1"
       }
     },
@@ -12416,8 +12416,8 @@
       "version": "file:packages/sha256-universal",
       "requires": {
         "@aws-crypto/sha256-browser": "file:../sha256-browser",
-        "@aws-sdk/hash-node": "^3.0.0",
-        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/hash-node": "^3.110.0",
+        "@aws-sdk/types": "^3.110.0",
         "tslib": "^1.11.1"
       }
     },
@@ -12430,17 +12430,17 @@
     "@aws-crypto/util": {
       "version": "file:packages/util",
       "requires": {
-        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/types": "^3.110.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       }
     },
     "@aws-sdk/hash-node": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.55.0.tgz",
-      "integrity": "sha512-2UdYwY/++AlzWEAFaK9wOed2QSxbzV527vmqKjReLHpPKPrSIlooUxlTH3LU6Y6WVDAzDRtLK43KUVXTLgGK1A==",
+      "version": "3.110.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.110.0.tgz",
+      "integrity": "sha512-wakl+kP2O8wTGYiQ3InZy+CVfGrIpFfq9fo4zif9PZac0BbUbguUU1dkY34uZiaf+4o2/9MoDYrHU2HYeXKxWw==",
       "requires": {
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/types": "3.110.0",
         "@aws-sdk/util-buffer-from": "3.55.0",
         "tslib": "^2.3.1"
       },
@@ -12468,9 +12468,9 @@
       }
     },
     "@aws-sdk/types": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.55.0.tgz",
-      "integrity": "sha512-wrDZjuy1CVAYxDCbm3bWQIKMGfNs7XXmG0eG4858Ixgqmq2avsIn5TORy8ynBxcXn9aekV/+tGEQ7BBSYzIVNQ=="
+      "version": "3.110.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.110.0.tgz",
+      "integrity": "sha512-dLVoqODU3laaqNFPyN1QLtlQnwX4gNPMXptEBIt/iJpuZf66IYJe6WCzVZGt4Zfa1CnUmrlA428AzdcA/KCr2A=="
     },
     "@aws-sdk/util-buffer-from": {
       "version": "3.55.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "packages/*"
   ],
   "devDependencies": {
-    "@aws-sdk/types": "^3.0.0",
+    "@aws-sdk/types": "^3.110.0",
     "@aws-sdk/util-buffer-from": "^3.29.0",
     "@aws-sdk/util-hex-encoding": "^3.29.0",
     "@aws-sdk/util-utf8-browser": "^3.29.0",

--- a/packages/crc32/package.json
+++ b/packages/crc32/package.json
@@ -20,7 +20,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-crypto/util": "file:../util",
-    "@aws-sdk/types": "^3.1.0",
+    "@aws-sdk/types": "^3.110.0",
     "tslib": "^1.11.1"
   }
 }

--- a/packages/crc32c/package.json
+++ b/packages/crc32c/package.json
@@ -20,7 +20,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-crypto/util": "file:../util",
-    "@aws-sdk/types": "^3.1.0",
+    "@aws-sdk/types": "^3.110.0",
     "tslib": "^1.11.1"
   },
   "publishConfig": {

--- a/packages/random-source-node/package.json
+++ b/packages/random-source-node/package.json
@@ -18,7 +18,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/types": "^3.1.0",
+    "@aws-sdk/types": "^3.110.0",
     "tslib": "^1.11.1"
   },
   "types": "./build/index.d.ts"

--- a/packages/random-source-universal/package.json
+++ b/packages/random-source-universal/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@aws-crypto/random-source-browser": "file:../random-source-browser",
     "@aws-crypto/random-source-node": "file:../random-source-node",
-    "@aws-sdk/types": "^3.1.0",
+    "@aws-sdk/types": "^3.110.0",
     "tslib": "^1.11.1"
   },
   "browser": {

--- a/packages/sha1-browser/package.json
+++ b/packages/sha1-browser/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@aws-crypto/ie11-detection": "file:../ie11-detection",
     "@aws-crypto/supports-web-crypto": "file:../supports-web-crypto",
-    "@aws-sdk/types": "^3.1.0",
+    "@aws-sdk/types": "^3.110.0",
     "@aws-sdk/util-locate-window": "^3.0.0",
     "@aws-sdk/util-utf8-browser": "^3.0.0",
     "tslib": "^1.11.1"

--- a/packages/sha256-browser/package.json
+++ b/packages/sha256-browser/package.json
@@ -21,7 +21,7 @@
     "@aws-crypto/sha256-js": "file:../sha256-js",
     "@aws-crypto/supports-web-crypto": "file:../supports-web-crypto",
     "@aws-crypto/util": "file:../util",
-    "@aws-sdk/types": "^3.1.0",
+    "@aws-sdk/types": "^3.110.0",
     "@aws-sdk/util-locate-window": "^3.0.0",
     "@aws-sdk/util-utf8-browser": "^3.0.0",
     "tslib": "^1.11.1"

--- a/packages/sha256-js/package.json
+++ b/packages/sha256-js/package.json
@@ -20,7 +20,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-crypto/util": "file:../util",
-    "@aws-sdk/types": "^3.1.0",
+    "@aws-sdk/types": "^3.110.0",
     "tslib": "^1.11.1"
   }
 }

--- a/packages/sha256-universal/package.json
+++ b/packages/sha256-universal/package.json
@@ -18,8 +18,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-crypto/sha256-browser": "file:../sha256-browser",
-    "@aws-sdk/hash-node": "^3.0.0",
-    "@aws-sdk/types": "^3.1.0",
+    "@aws-sdk/hash-node": "^3.110.0",
+    "@aws-sdk/types": "^3.110.0",
     "tslib": "^1.11.1"
   },
   "main": "./build/index.js",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -19,7 +19,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/types": "^3.1.0",
+    "@aws-sdk/types": "^3.110.0",
     "@aws-sdk/util-utf8-browser": "^3.0.0",
     "tslib": "^1.11.1"
   },


### PR DESCRIPTION
_Issue #, if available:_ #337

_Description of changes:_ Updated @aws-sdk/types via the following pattern:
1. `npm install @aws-sdk/types@^3.110.0 --save-dev`
2. For package in packages:
`cd package; less package.json; if aws-sdk/types present: npm install @aws-sdk/types@^3.110.0`
3. Test those changes
4. Check package lock for any hold out types@^3.55.0, see `@aws-sdk/hash-node` bringing it in
5. `cd packages/sha256-universall; npm install @aws-sdk/hash-node@^3.110.0`
6. From root, run `npm run clean; npm run test;`

Should close #337 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
