### PR TITLE
sha256 packages: clarify hmac support

### DIFF
--- a/packages/sha256-browser/README.md
+++ b/packages/sha256-browser/README.md
@@ -6,10 +6,21 @@ to provide a consistent interface for SHA256.
 
 ## Usage
 
+- To hash "some data"
 ```
 import {Sha256} from '@aws-crypto/sha256-browser'
 
 const hash = new Sha256();
+hash.update('some data');
+const result = await hash.digest();
+
+```
+
+- To hmac "some data" with "a key"
+```
+import {Sha256} from '@aws-crypto/sha256-browser'
+
+const hash = new Sha256('a key');
 hash.update('some data');
 const result = await hash.digest();
 

--- a/packages/sha256-js/README.md
+++ b/packages/sha256-js/README.md
@@ -4,10 +4,21 @@ A pure JS implementation SHA256.
 
 ## Usage
 
+- To hash "some data"
 ```
 import {Sha256} from '@aws-crypto/sha256-js';
 
 const hash = new Sha256();
+hash.update('some data');
+const result = await hash.digest();
+
+```
+
+- To hmac "some data" with "a key"
+```
+import {Sha256} from '@aws-crypto/sha256-js';
+
+const hash = new Sha256('a key');
 hash.update('some data');
 const result = await hash.digest();
 

--- a/packages/sha256-js/test/jsSha256.test.ts
+++ b/packages/sha256-js/test/jsSha256.test.ts
@@ -82,7 +82,7 @@ describe("Sha256", () => {
 
   idx = 0;
   for (const [key, data, result] of hmacTestVectors) {
-    it("should match known hash calculations: " + idx++, async () => {
+    it("should match known hmac calculations: " + idx++, async () => {
       const hash = new Sha256(key);
       hash.update(data);
       expect(await hash.digest()).to.deep.equal(result);

--- a/packages/sha256-universal/README.md
+++ b/packages/sha256-universal/README.md
@@ -4,10 +4,21 @@ A consistent interface for SHA256 across browsers and NodeJs
 
 ## Usage
 
+- To hash "some data"
 ```
 import {Sha256} from '@aws-crypto/sha256-universal'
 
 const hash = new Sha256();
+hash.update('some data');
+const result = await hash.digest();
+
+```
+
+- To hmac "some data" with "a key"
+```
+import {Sha256} from '@aws-crypto/sha256-universal'
+
+const hash = new Sha256('a key');
 hash.update('some data');
 const result = await hash.digest();
 


### PR DESCRIPTION
Adding Usage for hmac, updated tests to say hmac for clarity

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
