### PR TITLE
fix: correct package naming in "browser" fields

### DIFF
--- a/packages/sha256-universal/package.json
+++ b/packages/sha256-universal/package.json
@@ -26,7 +26,7 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "browser": {
-    "@aws/hash-node": false,
+    "@aws-sdk/hash-node": false,
     "crypto": false
   }
 }


### PR DESCRIPTION
Webpack 5 makes browser polyfills explicit. Webpack detects `@aws-sdk/hash-node` as something that includes node features to potentially pollfill while using `@aws-crypto/sha256-universal`. This can be resolved via a webpack config, but better to resolve the typo here.

```
BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "buffer": require.resolve("buffer/") }'
        - install 'buffer'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "buffer": false }
```

I assume a similar issue is happening [here](https://github.com/aws/aws-sdk-js-crypto-helpers/blob/master/packages/random-source-universal/package.json#L27) - but I'm just interested in `@aws-crypto/sha256-universal`
