### PR TITLE
fix: Use exact versioning on dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@aws-crypto/util": "file:packages/util"
       },
       "devDependencies": {
-        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/types": "3.222.0",
         "@aws-sdk/util-buffer-from": "^3.29.0",
         "@aws-sdk/util-hex-encoding": "^3.29.0",
         "@smithy/util-utf8": "^2.0.0",
@@ -45,7 +45,7 @@
         "sinon": "^16.0.0",
         "tmp": "^0.2.1",
         "ts-node": "^10.9.1",
-        "tslib": "^2.6.2",
+        "tslib": "2.6.2",
         "typescript": "^4.1.3",
         "verdaccio": "^5.13.1"
       }
@@ -121,13 +121,9 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.413.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.413.0.tgz",
-      "integrity": "sha512-j1xib0f/TazIFc5ySIKOlT1ujntRbaoG4LJFeEezz4ji03/wSJMI8Vi4KjzpBp8J1tTu0oRDnsxRIGixsUBeYQ==",
-      "dependencies": {
-        "@smithy/types": "^2.3.1",
-        "tslib": "^2.5.0"
-      },
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.222.0.tgz",
+      "integrity": "sha512-yXRYptInkfEFaOvWFxlRXsRh9jWOmQc1sZeKqjfx2UCtzNJ7ebedN0VfCz4SaDotcw9Q4JWuN66qhRMJjDx7/w==",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -2681,17 +2677,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-1.1.0.tgz",
       "integrity": "sha512-twpQ/n+3OWZJ7Z+xu43MJErmhB/WO/mMTnqR6PwWQShvSJ/emx5d1N59LQZk6ZpTAeuRWrc+eHhkzTp9NFjNRQ==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/types": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.3.2.tgz",
-      "integrity": "sha512-iH0cdKi7HQlzfAM3w2shFk/qZYKAqJWswtpmQpPtlruF+uFZeGEpMJjgDRyhWiddfVM4e2oP4nMaOBsMy6lXgg==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -13338,8 +13323,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/util": "file:../util",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^2.6.2"
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "2.6.2"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -13351,8 +13336,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/util": "file:../util",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^2.6.2"
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "2.6.2"
       }
     },
     "packages/random-source-browser": {
@@ -13362,7 +13347,7 @@
       "dependencies": {
         "@aws-crypto/supports-web-crypto": "file:../supports-web-crypto",
         "@aws-sdk/util-locate-window": "^3.0.0",
-        "tslib": "^2.6.2"
+        "tslib": "2.6.2"
       }
     },
     "packages/random-source-node": {
@@ -13370,8 +13355,8 @@
       "version": "5.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^2.6.2"
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "2.6.2"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -13384,8 +13369,8 @@
       "dependencies": {
         "@aws-crypto/random-source-browser": "file:../random-source-browser",
         "@aws-crypto/random-source-node": "file:../random-source-node",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^2.6.2"
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "2.6.2"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -13398,10 +13383,10 @@
       "dependencies": {
         "@aws-crypto/supports-web-crypto": "file:../supports-web-crypto",
         "@aws-crypto/util": "file:../util",
-        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/types": "3.222.0",
         "@aws-sdk/util-locate-window": "^3.0.0",
         "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.6.2"
+        "tslib": "2.6.2"
       }
     },
     "packages/sha256-browser": {
@@ -13412,10 +13397,10 @@
         "@aws-crypto/sha256-js": "file:../sha256-js",
         "@aws-crypto/supports-web-crypto": "file:../supports-web-crypto",
         "@aws-crypto/util": "file:../util",
-        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/types": "3.222.0",
         "@aws-sdk/util-locate-window": "^3.0.0",
         "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.6.2"
+        "tslib": "2.6.2"
       }
     },
     "packages/sha256-js": {
@@ -13424,8 +13409,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/util": "file:../util",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^2.6.2"
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "2.6.2"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -13438,8 +13423,8 @@
       "dependencies": {
         "@aws-crypto/sha256-browser": "file:../sha256-browser",
         "@aws-sdk/hash-node": "^3.110.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^2.6.2"
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "2.6.2"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -13450,7 +13435,7 @@
       "version": "5.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "^2.6.2"
+        "tslib": "2.6.2"
       }
     },
     "packages/util": {
@@ -13458,9 +13443,9 @@
       "version": "5.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/types": "3.222.0",
         "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.6.2"
+        "tslib": "2.6.2"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "packages/*"
   ],
   "devDependencies": {
-    "@aws-sdk/types": "^3.222.0",
+    "@aws-sdk/types": "3.222.0",
     "@aws-sdk/util-buffer-from": "^3.29.0",
     "@aws-sdk/util-hex-encoding": "^3.29.0",
     "@smithy/util-utf8": "^2.0.0",
@@ -59,7 +59,7 @@
     "sinon": "^16.0.0",
     "tmp": "^0.2.1",
     "ts-node": "^10.9.1",
-    "tslib": "^2.6.2",
+    "tslib": "2.6.2",
     "typescript": "^4.1.3",
     "verdaccio": "^5.13.1"
   },

--- a/packages/crc32/package.json
+++ b/packages/crc32/package.json
@@ -22,8 +22,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-crypto/util": "file:../util",
-    "@aws-sdk/types": "^3.222.0",
-    "tslib": "^2.6.2"
+    "@aws-sdk/types": "3.222.0",
+    "tslib": "2.6.2"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/crc32c/package.json
+++ b/packages/crc32c/package.json
@@ -22,8 +22,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-crypto/util": "file:../util",
-    "@aws-sdk/types": "^3.222.0",
-    "tslib": "^2.6.2"
+    "@aws-sdk/types": "3.222.0",
+    "tslib": "2.6.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/random-source-browser/package.json
+++ b/packages/random-source-browser/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@aws-crypto/supports-web-crypto": "file:../supports-web-crypto",
     "@aws-sdk/util-locate-window": "^3.0.0",
-    "tslib": "^2.6.2"
+    "tslib": "2.6.2"
   },
   "main": "./build/main/index.js",
   "module": "./build/module/index.js",

--- a/packages/random-source-node/package.json
+++ b/packages/random-source-node/package.json
@@ -22,8 +22,8 @@
   "homepage": "https://github.com/aws/aws-sdk-js-crypto-helpers/tree/master/packages/random-source-node",
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/types": "^3.222.0",
-    "tslib": "^2.6.2"
+    "@aws-sdk/types": "3.222.0",
+    "tslib": "2.6.2"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/random-source-universal/package.json
+++ b/packages/random-source-universal/package.json
@@ -20,8 +20,8 @@
   "dependencies": {
     "@aws-crypto/random-source-browser": "file:../random-source-browser",
     "@aws-crypto/random-source-node": "file:../random-source-node",
-    "@aws-sdk/types": "^3.222.0",
-    "tslib": "^2.6.2"
+    "@aws-sdk/types": "3.222.0",
+    "tslib": "2.6.2"
   },
   "browser": {
     "@aws/crypto-random-source-node": false

--- a/packages/sha1-browser/package.json
+++ b/packages/sha1-browser/package.json
@@ -20,10 +20,10 @@
   "dependencies": {
     "@aws-crypto/supports-web-crypto": "file:../supports-web-crypto",
     "@aws-crypto/util": "file:../util",
-    "@aws-sdk/types": "^3.222.0",
+    "@aws-sdk/types": "3.222.0",
     "@aws-sdk/util-locate-window": "^3.0.0",
     "@smithy/util-utf8": "^2.0.0",
-    "tslib": "^2.6.2"
+    "tslib": "2.6.2"
   },
   "main": "./build/main/index.js",
   "module": "./build/module/index.js",

--- a/packages/sha256-browser/package.json
+++ b/packages/sha256-browser/package.json
@@ -21,10 +21,10 @@
     "@aws-crypto/sha256-js": "file:../sha256-js",
     "@aws-crypto/supports-web-crypto": "file:../supports-web-crypto",
     "@aws-crypto/util": "file:../util",
-    "@aws-sdk/types": "^3.222.0",
+    "@aws-sdk/types": "3.222.0",
     "@aws-sdk/util-locate-window": "^3.0.0",
     "@smithy/util-utf8": "^2.0.0",
-    "tslib": "^2.6.2"
+    "tslib": "2.6.2"
   },
   "main": "./build/main/index.js",
   "module": "./build/module/index.js",

--- a/packages/sha256-js/package.json
+++ b/packages/sha256-js/package.json
@@ -22,8 +22,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-crypto/util": "file:../util",
-    "@aws-sdk/types": "^3.222.0",
-    "tslib": "^2.6.2"
+    "@aws-sdk/types": "3.222.0",
+    "tslib": "2.6.2"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/sha256-universal/package.json
+++ b/packages/sha256-universal/package.json
@@ -20,8 +20,8 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "file:../sha256-browser",
     "@aws-sdk/hash-node": "^3.110.0",
-    "@aws-sdk/types": "^3.222.0",
-    "tslib": "^2.6.2"
+    "@aws-sdk/types": "3.222.0",
+    "tslib": "2.6.2"
   },
   "main": "./build/main/index.js",
   "module": "./build/module/index.js",

--- a/packages/supports-web-crypto/package.json
+++ b/packages/supports-web-crypto/package.json
@@ -22,6 +22,6 @@
   "module": "./build/module/index.js",
   "types": "./build/main/index.d.ts",
   "dependencies": {
-    "tslib": "^2.6.2"
+    "tslib": "2.6.2"
   }
 }

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -21,9 +21,9 @@
   "homepage": "https://github.com/aws/aws-sdk-js-crypto-helpers/tree/master/packages/util",
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/types": "^3.222.0",
+    "@aws-sdk/types": "3.222.0",
     "@smithy/util-utf8": "^2.0.0",
-    "tslib": "^2.6.2"
+    "tslib": "2.6.2"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
_Issue #, if available:_
https://github.com/aws/aws-sdk-js-crypto-helpers/issues/779

_Description of changes:_
Use exact versioning on dependencies.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
