### PR TITLE
chore: update depricated packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,8 +25,8 @@
       },
       "devDependencies": {
         "@aws-sdk/types": "~3.413.0",
-        "@aws-sdk/util-buffer-from": "^3.29.0",
-        "@aws-sdk/util-hex-encoding": "^3.29.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
         "@smithy/util-utf8": "^2.0.0",
         "@types/chai": "^4.2.12",
         "@types/mocha": "^10.0.0",
@@ -113,34 +113,6 @@
       "integrity": "sha512-j1xib0f/TazIFc5ySIKOlT1ujntRbaoG4LJFeEezz4ji03/wSJMI8Vi4KjzpBp8J1tTu0oRDnsxRIGixsUBeYQ==",
       "dependencies": {
         "@smithy/types": "^2.3.1",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-buffer-from": {
-      "version": "3.374.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.374.0.tgz",
-      "integrity": "sha512-7SsNgXINcTVIumqXBYm8r7+Et87tPwInmoEt2h08zSryStE0CJDlGvCaeYY0EpjnZKAkCkAN3+CMQkTc7nYHUQ==",
-      "deprecated": "This package has moved to @smithy/util-buffer-from",
-      "dev": true,
-      "dependencies": {
-        "@smithy/util-buffer-from": "^1.0.1",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-hex-encoding": {
-      "version": "3.374.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.374.0.tgz",
-      "integrity": "sha512-14X7MDYCFle2Cuq0/Hvz2CHQoYVeoKKBY2Uf+wn0lKnKU+f0K81xRObUM/A7bLmZX4jFRk83gyE8Rj3BOqBdfA==",
-      "deprecated": "This package has moved to @smithy/util-hex-encoding",
-      "dev": true,
-      "dependencies": {
-        "@smithy/util-hex-encoding": "^1.0.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2209,15 +2181,15 @@
       "dev": true
     },
     "node_modules/@smithy/is-array-buffer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-1.1.0.tgz",
-      "integrity": "sha512-twpQ/n+3OWZJ7Z+xu43MJErmhB/WO/mMTnqR6PwWQShvSJ/emx5d1N59LQZk6ZpTAeuRWrc+eHhkzTp9NFjNRQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
       "dev": true,
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/types": {
@@ -2232,28 +2204,28 @@
       }
     },
     "node_modules/@smithy/util-buffer-from": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-1.1.0.tgz",
-      "integrity": "sha512-9m6NXE0ww+ra5HKHCHig20T+FAwxBAm7DIdwc/767uGWbRcY720ybgPacQNB96JMOI7xVr/CDa3oMzKmW4a+kw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
       "dev": true,
       "dependencies": {
-        "@smithy/is-array-buffer": "^1.1.0",
-        "tslib": "^2.5.0"
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/util-hex-encoding": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-1.1.0.tgz",
-      "integrity": "sha512-7UtIE9eH0u41zpB60Jzr0oNCQ3hMJUabMcKRUVjmyHTXiWDE4vjSqN6qlih7rCNeKGbioS7f/y2Jgym4QZcKFg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+      "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
       "dev": true,
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/util-utf8": {

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
   ],
   "devDependencies": {
     "@aws-sdk/types": "~3.413.0",
-    "@aws-sdk/util-buffer-from": "^3.29.0",
-    "@aws-sdk/util-hex-encoding": "^3.29.0",
+    "@smithy/util-buffer-from": "^3.0.0",
+    "@smithy/util-hex-encoding": "^3.0.0",
     "@smithy/util-utf8": "^2.0.0",
     "@types/chai": "^4.2.12",
     "@types/mocha": "^10.0.0",

--- a/packages/sha256-js/src/knownHashes.fixture.ts
+++ b/packages/sha256-js/src/knownHashes.fixture.ts
@@ -1,4 +1,4 @@
-import { fromHex } from "@aws-sdk/util-hex-encoding";
+import { fromHex } from "@smithy/util-hex-encoding";
 
 const millionChars = new Uint8Array(1000000);
 for (let i = 0; i < 1000000; i++) {


### PR DESCRIPTION
These packages:
- @aws-sdk/util-buffer-from
- @aws-sdk/util-hex-encoding

have been depricated in favor of:

- @smithy/util-buffer-from
- @smithy/util-hex-encoding

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
