### PR TITLE
fix(release): Prevent script injection via dist_tag input

### DIFF
--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -81,7 +81,10 @@ jobs:
         run: npm install -g npm@latest
       - run: npm ci --unsafe-perm
       - run: npm run build --if-present
-      - run: npx lerna publish from-package --yes --dist-tag ${{ github.event.inputs.dist_tag }}
+      - name: Publish
+        env:
+          DIST_TAG: ${{ github.event.inputs.dist_tag }}
+        run: npx lerna publish from-package --yes --dist-tag "$DIST_TAG"
 
   # Once publishing is complete, validate that the published packages are useable
   validate:


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
Bind the workflow_dispatch dist_tag input to a DIST_TAG environment variable and reference it quoted in the lerna publish run step, instead of interpolating it directly into the inline shell command.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
